### PR TITLE
Solution to early image retrieving problem for Python

### DIFF
--- a/python/submit.py
+++ b/python/submit.py
@@ -2,6 +2,7 @@ import requests
 import urllib
 import time
 import sys
+from PIL import Image
 
 r = requests.post('http://turbo.deepart.io/api/post/',
                   data={'style': sys.argv[2],
@@ -10,5 +11,18 @@ r = requests.post('http://turbo.deepart.io/api/post/',
 img=r.text
 link=("http://turbo.deepart.io/media/output/%s.jpg" % img)
 print link
-time.sleep(1)
-urllib.urlretrieve (link, "res.jpg")
+
+max_num_seconds = 15
+
+for i in range(max_num_seconds):
+
+    time.sleep(1)
+    urllib.urlretrieve (link, "res.jpg")
+ 
+    try:
+        img = Image.open("res.jpg")
+        img.close()
+        break
+
+    except:
+        print "Try #"+str(i+1)+": Retrieving image failed (deepart-api needs more time). Trying again after 1s."


### PR DESCRIPTION
Added a loop to python/submit.py that checks every 1s whether image is ready for retrieving. Solves the problem that sometimes the image is not yet ready, in which case the result (res.jpg) was still saved, but could not be opened.